### PR TITLE
Plumb resources into workload and add go env

### DIFF
--- a/build/package/peerd-helm/templates/peerd-ds.yml
+++ b/build/package/peerd-helm/templates/peerd-ds.yml
@@ -46,6 +46,8 @@ spec:
               name: router
             - containerPort: 5004
               name: metrics
+          resources:
+            {{- toYaml .Values.peerd.resources | nindent 8 }}
           volumeMounts:
             - name: metricsmount
               mountPath: "/var/log/peerdmetrics"

--- a/build/package/peerd-helm/templates/peerd-ds.yml
+++ b/build/package/peerd-helm/templates/peerd-ds.yml
@@ -47,7 +47,24 @@ spec:
             - containerPort: 5004
               name: metrics
           resources:
-            {{- toYaml .Values.peerd.resources | nindent 8 }}
+            {{- toYaml .Values.peerd.resources | nindent 10 }}
+          {{- if or ((.Values.peerd.resources).limits.cpu) ((.Values.peerd.resources).limits.memory) }}
+          env:
+          {{- end }}
+            {{- if ((.Values.peerd.resources).limits).cpu }}
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.cpu
+                  divisor: 1
+            {{- end }}
+            {{- if ((.Values.peerd.resources).limits).memory }}
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.memory
+                  divisor: 1
+            {{- end }}
           volumeMounts:
             - name: metricsmount
               mountPath: "/var/log/peerdmetrics"


### PR DESCRIPTION
The resources in values file is not properly plumbed into the workload during rendering. Added resources in workload and configured related go envvars.