### PR TITLE
fix: amend copyright attributions

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,5 @@
 Copyright (c) Microsoft Corporation.
+Portions (c) 2023 Xenit AB and 2024 The Spegel Authors.
 
 MIT License
 

--- a/pkg/containerd/hosts.go
+++ b/pkg/containerd/hosts.go
@@ -1,4 +1,5 @@
-// Copyright (c) Microsoft Corporation.
+// Initial Copyright (c) 2023 Xenit AB and 2024 The Spegel Authors.
+// Portions Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 package containerd
 

--- a/pkg/containerd/hosts_test.go
+++ b/pkg/containerd/hosts_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) Microsoft Corporation.
+// Initial Copyright (c) 2023 Xenit AB and 2024 The Spegel Authors.
+// Portions Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 package containerd
 

--- a/pkg/containerd/mocks/contentstore.go
+++ b/pkg/containerd/mocks/contentstore.go
@@ -1,4 +1,5 @@
-// Copyright (c) Microsoft Corporation.
+// Initial Copyright (c) 2023 Xenit AB and 2024 The Spegel Authors.
+// Portions Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 package mocks
 

--- a/pkg/containerd/reference.go
+++ b/pkg/containerd/reference.go
@@ -1,4 +1,5 @@
-// Copyright (c) Microsoft Corporation.
+// Initial Copyright (c) 2023 Xenit AB and 2024 The Spegel Authors.
+// Portions Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 package containerd
 

--- a/pkg/containerd/reference_test.go
+++ b/pkg/containerd/reference_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) Microsoft Corporation.
+// Initial Copyright (c) 2023 Xenit AB and 2024 The Spegel Authors.
+// Portions Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 package containerd
 

--- a/pkg/containerd/store.go
+++ b/pkg/containerd/store.go
@@ -1,4 +1,5 @@
-// Copyright (c) Microsoft Corporation.
+// Initial Copyright (c) 2023 Xenit AB and 2024 The Spegel Authors.
+// Portions Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 package containerd
 

--- a/pkg/containerd/store_test.go
+++ b/pkg/containerd/store_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) Microsoft Corporation.
+// Initial Copyright (c) 2023 Xenit AB and 2024 The Spegel Authors.
+// Portions Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 package containerd
 

--- a/pkg/discovery/content/provider/provider_test.go
+++ b/pkg/discovery/content/provider/provider_test.go
@@ -1,4 +1,5 @@
 // Copyright (c) Microsoft Corporation.
+// Portions (c) 2023 Xenit AB and 2024 The Spegel Authors.
 // Licensed under the MIT License.
 package provider
 

--- a/pkg/discovery/content/registry/mirror_test.go
+++ b/pkg/discovery/content/registry/mirror_test.go
@@ -1,4 +1,5 @@
 // Copyright (c) Microsoft Corporation.
+// Portions (c) 2023 Xenit AB and 2024 The Spegel Authors.
 // Licensed under the MIT License.
 package registry
 

--- a/pkg/oci/distribution/v2.go
+++ b/pkg/oci/distribution/v2.go
@@ -1,4 +1,5 @@
 // Copyright (c) Microsoft Corporation.
+// Portions (c) 2023 Xenit AB and 2024 The Spegel Authors.
 // Licensed under the MIT License.
 package distribution
 

--- a/pkg/oci/distribution/v2_test.go
+++ b/pkg/oci/distribution/v2_test.go
@@ -1,4 +1,5 @@
 // Copyright (c) Microsoft Corporation.
+// Portions (c) 2023 Xenit AB and 2024 The Spegel Authors.
 // Licensed under the MIT License.
 package distribution
 


### PR DESCRIPTION
This commit amends copyright attributions that were omitted due to an oversight on part of the Peerd authors. Copyright header attributions in a few files have been updated to include "2023 Xenit AB and 2024 The Spegel Authors". The attribution in the LICENSE file has also been updated to reflect the same.

Fixes #109